### PR TITLE
Add Kotlin deep-dive series (origins + coroutines & Flow)

### DIFF
--- a/src/content/deep-dives/kotlin-coroutines.mdx
+++ b/src/content/deep-dives/kotlin-coroutines.mdx
@@ -1,0 +1,231 @@
+---
+title: "Kotlin Coroutines & Flow — A Million Threads That Aren't Threads"
+description: "How Kotlin makes asynchronous code read like ordinary code. A deep dive into suspend functions and the state machine behind them, dispatchers, structured concurrency, cancellation, and the cold and hot streams of Flow."
+category: "Kotlin"
+color: "#7F52FF"
+subject: "Kotlin: Concurrency"
+order: 1
+publishedAt: 2026-06-04
+topics:
+  - id: the-callback-pyramid
+    title: "The callback pyramid of doom"
+    summary: |
+      Almost every interesting program has to <em>wait</em>. It waits for a network response, a database query, a file to load, a user to tap a button. The hard question of concurrent programming is: what does the rest of your program do while it waits?
+      <br><br>
+      The naive answer — just block and wait — is a disaster on a single thread. If your app's main thread blocks for a one-second network call, the UI freezes for a full second. So for decades the standard solution was the <strong>callback</strong>: "go do this slow thing, and call me back when you're done." It works, but it does not compose. Chain a few async steps together and you get the infamous <strong>pyramid of doom</strong>.
+      <br><br>
+      <pre><code>// Callback hell: each step nests inside the last&#10;fetchUser(id) { user -&gt;&#10;    fetchProfile(user) { profile -&gt;&#10;        fetchPhoto(profile) { photo -&gt;&#10;            updateUI(user, profile, photo)&#10;        } // error handling? cancellation? good luck&#10;    }&#10;}</code></pre>
+      The logic drifts ever further to the right. Error handling becomes a nightmare — each callback needs its own. Cancelling the whole chain partway through is nearly impossible. The code no longer reads in the order it executes.
+      <br><br>
+      Other languages attacked this with <code>Future</code>/<code>Promise</code> chains (<code>.then().then().catch()</code>) and later with <code>async</code>/<code>await</code>. Kotlin's answer is <strong>coroutines</strong>, and its central promise is simple but radical: <em>write asynchronous code that looks exactly like ordinary sequential code.</em>
+      <br><br>
+      <pre><code>// The same logic with coroutines — flat, sequential, cancellable&#10;suspend fun loadScreen(id: String) {&#10;    val user = fetchUser(id)&#10;    val profile = fetchProfile(user)&#10;    val photo = fetchPhoto(profile)&#10;    updateUI(user, profile, photo)&#10;}</code></pre>
+      No nesting. No callbacks. Errors propagate with ordinary <code>try/catch</code>. And, as we will see, the whole thing can be cancelled by cancelling one parent. The thread is never blocked while waiting. This is the payoff. The rest of this episode explains how it works.
+
+  - id: what-is-a-coroutine
+    title: "What a coroutine actually is"
+    summary: |
+      The word <strong>coroutine</strong> is older than you might think. It was coined by <strong>Melvin Conway in 1958</strong> — the same Conway of "Conway's Law" — to describe routines that cooperate by voluntarily handing control back and forth. Coroutines predate threads as a concurrency idea by decades; they fell out of fashion, then came roaring back.
+      <br><br>
+      The key distinction is between <strong>suspending</strong> and <strong>blocking</strong>.
+      <br><br>
+      • A <strong>blocked</strong> thread is stuck. It holds its expensive ~1 MB of memory and does nothing useful until the thing it waits for completes. The operating system cannot reuse it.<br>
+      • A <strong>suspended</strong> coroutine has stepped aside. It saves where it was, releases the thread entirely, and lets that thread go run other work. When its data is ready, it <em>resumes</em> — possibly on a different thread.<br><br>
+      That difference is everything. Because a suspended coroutine costs almost nothing — just a small object on the heap — you can have an absurd number of them.
+      <br><br>
+      <pre><code>import kotlinx.coroutines.*&#10;&#10;fun main() = runBlocking {&#10;    // Launch 100,000 coroutines. Try this with threads and your machine dies.&#10;    repeat(100_000) {&#10;        launch {&#10;            delay(1000L)   // suspends — does NOT block a thread&#10;            print(".")&#10;        }&#10;    }&#10;}</code></pre>
+      This program runs fine, finishing in about a second, on a handful of threads. The equivalent with 100,000 real threads would exhaust memory long before it started. Coroutines are sometimes called "lightweight threads," but that undersells it — they are a fundamentally cheaper unit of work.
+      <br><br>
+      One more piece of history worth knowing: coroutines are <em>not</em> part of the Kotlin language in the way <code>if</code> or <code>class</code> are. The language provides exactly one primitive — the <code>suspend</code> keyword — and everything else (<code>launch</code>, <code>async</code>, <code>Flow</code>, dispatchers) lives in a separate library, <code>kotlinx.coroutines</code>. This was a deliberate choice by the team, led by <strong>Roman Elizarov</strong>: keep the language small, put the machinery in a library that can evolve independently.
+
+  - id: suspend-and-the-state-machine
+    title: "suspend and the state machine"
+    summary: |
+      How can a function pause in the middle and resume later? There is no magic — just a clever compiler trick that is worth understanding, because it demystifies the whole model.
+      <br><br>
+      When you mark a function <code>suspend</code>, the Kotlin compiler rewrites it using <strong>Continuation-Passing Style (CPS)</strong>. It secretly adds one hidden parameter — a <code>Continuation</code> — which is essentially a callback representing "the rest of the program." So this:
+      <br><br>
+      <pre><code>suspend fun loadUser(id: String): User</code></pre>
+      is compiled to something closer to this under the hood:
+      <br><br>
+      <pre><code>fun loadUser(id: String, cont: Continuation&lt;User&gt;): Any?</code></pre>
+      Then, at every point where the function might suspend, the compiler slices it into pieces and stitches them back together as a <strong>state machine</strong>. Each suspension point becomes a labelled state. When the function resumes, it jumps back to the right label with its local variables restored.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 330" role="img" aria-label="A suspend function compiled into a resumable state machine" style="max-width: 100%; height: auto;"><defs><marker id="sm-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#7F52FF"/></marker></defs><style>.sm-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.sm-title{font-size:16px;font-weight:600}.sm-code{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:12px;fill:#fff;font-weight:600}.sm-label{font-size:11px;fill:#64748b}.sm-state{font-size:12px;font-weight:700;fill:#7F52FF}</style><text x="360" y="24" text-anchor="middle" class="sm-t sm-title">One suspend function → a resumable state machine</text><rect x="40" y="55" width="180" height="55" rx="8" fill="#7F52FF"/><text x="130" y="80" text-anchor="middle" class="sm-t sm-code">state 0: start</text><text x="130" y="98" text-anchor="middle" class="sm-t sm-code" style="font-size:10px">fetchUser()</text><rect x="270" y="55" width="180" height="55" rx="8" fill="#7F52FF"/><text x="360" y="80" text-anchor="middle" class="sm-t sm-code">state 1</text><text x="360" y="98" text-anchor="middle" class="sm-t sm-code" style="font-size:10px">fetchProfile()</text><rect x="500" y="55" width="180" height="55" rx="8" fill="#7F52FF"/><text x="590" y="80" text-anchor="middle" class="sm-t sm-code">state 2</text><text x="590" y="98" text-anchor="middle" class="sm-t sm-code" style="font-size:10px">fetchPhoto()</text><line x1="220" y1="82" x2="268" y2="82" stroke="#7F52FF" stroke-width="2" marker-end="url(#sm-arr)"/><line x1="450" y1="82" x2="498" y2="82" stroke="#7F52FF" stroke-width="2" marker-end="url(#sm-arr)"/><text x="244" y="74" text-anchor="middle" class="sm-t sm-label">resume</text><text x="474" y="74" text-anchor="middle" class="sm-t sm-label">resume</text><g><path d="M130 110 C 130 150, 130 150, 130 175" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#sm-arr)"/><path d="M360 110 C 360 150, 360 150, 360 175" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#sm-arr)"/><path d="M590 110 C 590 150, 590 150, 590 175" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#sm-arr)"/></g><rect x="60" y="180" width="600" height="64" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5"/><text x="360" y="205" text-anchor="middle" class="sm-t sm-label">At each suspension point the coroutine SUSPENDS:</text><text x="360" y="225" text-anchor="middle" class="sm-t sm-label">saves its state + locals into the Continuation, releases the thread, and returns COROUTINE_SUSPENDED.</text><rect x="160" y="262" width="400" height="50" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/><text x="360" y="284" text-anchor="middle" class="sm-t sm-label" style="font-weight:600;fill:#10b981">When the result is ready, the Continuation is called →</text><text x="360" y="301" text-anchor="middle" class="sm-t sm-label">the machine jumps to the next state and continues.</text></svg>
+      <br><br>
+      This is why a single <code>suspend</code> function can "pause" without a thread sitting idle: at each suspension point it literally returns control to its caller (returning a special <code>COROUTINE_SUSPENDED</code> marker), freeing the thread. When the awaited value arrives, the saved <code>Continuation</code> is invoked and the state machine advances. You write straight-line code; the compiler builds the callback machinery for you.
+      <br><br>
+      A crucial consequence: you can only call a <code>suspend</code> function from another <code>suspend</code> function, or from inside a coroutine builder. Suspension is "coloured" — it propagates up the call stack until it reaches something that knows how to launch a coroutine.
+
+  - id: builders-launch-async
+    title: "Coroutine builders: launch, async, runBlocking"
+    summary: |
+      You cannot call a <code>suspend</code> function from ordinary code directly — you need a <strong>coroutine builder</strong> to bridge the normal world and the suspending world. There are three you will meet constantly.
+      <br><br>
+      <strong><code>launch</code></strong> — fire-and-forget. It starts a coroutine that returns no result, and hands you back a <code>Job</code> you can use to cancel or wait on it.
+      <br><br>
+      <pre><code>val job = scope.launch {&#10;    saveToDatabase()   // we don't need a return value&#10;}&#10;job.cancel()           // ...but we can cancel it</code></pre>
+      <strong><code>async</code></strong> — when you want a result. It returns a <code>Deferred&lt;T&gt;</code> (a coroutine-aware "promise"). Call <code>await()</code> to suspend until the value is ready. This is also how you run things <em>concurrently</em>.
+      <br><br>
+      <pre><code>suspend fun loadDashboard() = coroutineScope {&#10;    // Both requests start immediately, running concurrently&#10;    val user = async { fetchUser() }&#10;    val feed = async { fetchFeed() }&#10;    // Suspend until BOTH are done&#10;    render(user.await(), feed.await())&#10;}</code></pre>
+      <strong><code>runBlocking</code></strong> — the bridge of last resort. It actually <em>blocks</em> the current thread until its coroutine finishes. You use it in <code>main()</code> functions and tests — places where you genuinely want to stop and wait — but almost never in production app code, because blocking is the very thing coroutines exist to avoid.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 230" role="img" aria-label="Comparison of launch, async and runBlocking builders" style="max-width: 100%; height: auto;"><style>.bd-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.bd-title{font-size:16px;font-weight:600}.bd-name{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:15px;font-weight:700;fill:#7F52FF}.bd-ret{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:11px;fill:#475569}.bd-desc{font-size:11px;fill:#64748b}</style><text x="360" y="24" text-anchor="middle" class="bd-t bd-title">Three ways into the coroutine world</text><rect x="30" y="48" width="205" height="150" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="2"/><text x="132" y="78" text-anchor="middle" class="bd-t bd-name">launch</text><text x="132" y="102" text-anchor="middle" class="bd-t bd-ret">returns Job</text><text x="132" y="130" text-anchor="middle" class="bd-t bd-desc">fire-and-forget</text><text x="132" y="148" text-anchor="middle" class="bd-t bd-desc">no result value</text><text x="132" y="172" text-anchor="middle" class="bd-t bd-desc">does not block</text><rect x="257" y="48" width="205" height="150" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/><text x="359" y="78" text-anchor="middle" class="bd-t bd-name">async</text><text x="359" y="102" text-anchor="middle" class="bd-t bd-ret">returns Deferred&lt;T&gt;</text><text x="359" y="130" text-anchor="middle" class="bd-t bd-desc">produces a result</text><text x="359" y="148" text-anchor="middle" class="bd-t bd-desc">.await() for value</text><text x="359" y="172" text-anchor="middle" class="bd-t bd-desc">for concurrency</text><rect x="484" y="48" width="206" height="150" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="2"/><text x="587" y="78" text-anchor="middle" class="bd-t bd-name">runBlocking</text><text x="587" y="102" text-anchor="middle" class="bd-t bd-ret">returns T</text><text x="587" y="130" text-anchor="middle" class="bd-t bd-desc">BLOCKS the thread</text><text x="587" y="148" text-anchor="middle" class="bd-t bd-desc">main() &amp; tests only</text><text x="587" y="172" text-anchor="middle" class="bd-t bd-desc">avoid in app code</text></svg>
+      <br><br>
+      <strong>The sequential-by-default gotcha.</strong> This trips up nearly everyone. If you simply <code>await()</code> right after each <code>async</code>, or just call two suspend functions in a row, they run <em>one after another</em>. Concurrency only happens when you start both <code>async</code> blocks <em>before</em> awaiting either. <code>suspend</code> means "can pause," not "runs in parallel."
+
+  - id: dispatchers-and-context
+    title: "Dispatchers: which thread runs the work"
+    summary: |
+      Coroutines suspend and resume — but when they are actively running, they still need a real thread. A <strong>dispatcher</strong> decides which thread (or thread pool) that is. It is part of the <code>CoroutineContext</code>, the bundle of metadata every coroutine carries.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" aria-label="The standard coroutine dispatchers and their purposes" style="max-width: 100%; height: auto;"><style>.dp-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.dp-title{font-size:16px;font-weight:600}.dp-name{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:13px;font-weight:700;fill:#7F52FF}.dp-desc{font-size:11px;fill:#64748b}.dp-use{font-size:11px;font-weight:600;fill:#1e293b}</style><text x="360" y="24" text-anchor="middle" class="dp-t dp-title">The standard dispatchers</text><rect x="30" y="48" width="320" height="85" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5"/><text x="50" y="74" class="dp-t dp-name">Dispatchers.Default</text><text x="50" y="97" class="dp-t dp-use">CPU-intensive work</text><text x="50" y="116" class="dp-t dp-desc">pool sized to CPU cores · sorting, parsing, math</text><rect x="370" y="48" width="320" height="85" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/><text x="390" y="74" class="dp-t dp-name">Dispatchers.IO</text><text x="390" y="97" class="dp-t dp-use">blocking I/O</text><text x="390" y="116" class="dp-t dp-desc">large elastic pool · network, disk, database</text><rect x="30" y="143" width="320" height="85" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/><text x="50" y="169" class="dp-t dp-name">Dispatchers.Main</text><text x="50" y="192" class="dp-t dp-use">UI thread</text><text x="50" y="211" class="dp-t dp-desc">single thread · update widgets, touch handlers</text><rect x="370" y="143" width="320" height="85" rx="8" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.5"/><text x="390" y="169" class="dp-t dp-name">Dispatchers.Unconfined</text><text x="390" y="192" class="dp-t dp-use">advanced / rarely used</text><text x="390" y="211" class="dp-t dp-desc">resumes on whatever thread called it · easy to misuse</text></svg>
+      <br><br>
+      The everyday tool for moving work between dispatchers is <code>withContext</code>. It suspends the current coroutine, runs its block on the requested dispatcher, and resumes you with the result — no callback, no thread juggling.
+      <br><br>
+      <pre><code>suspend fun loadImage(url: String): Bitmap {&#10;    // Suspend here, do the blocking download on the IO pool&#10;    val bytes = withContext(Dispatchers.IO) {&#10;        downloadBytes(url)&#10;    }&#10;    // Heavy decoding belongs on the CPU pool&#10;    return withContext(Dispatchers.Default) {&#10;        decodeBitmap(bytes)&#10;    }&#10;    // The caller (often on Main) is never blocked&#10;}</code></pre>
+      This is the pattern that keeps UIs smooth: the main thread launches the coroutine, the work hops to <code>IO</code> and <code>Default</code> as needed, and the final result lands back on <code>Main</code> to update the screen — all written as plain top-to-bottom code.
+
+  - id: structured-concurrency
+    title: "Structured concurrency"
+    summary: |
+      This is Kotlin's signature contribution to the field, and the idea Roman Elizarov championed in an influential 2018 essay. The principle: <strong>a coroutine cannot outlive its scope</strong>. Every coroutine is launched inside a <code>CoroutineScope</code> and becomes a child of that scope's <code>Job</code>, forming a tree.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" role="img" aria-label="A scope with parent and child coroutines, where cancelling the parent cancels all children" style="max-width: 100%; height: auto;"><defs><marker id="sc-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/></marker></defs><style>.sc-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.sc-title{font-size:16px;font-weight:600}.sc-box{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:12px;font-weight:600;fill:#fff}.sc-label{font-size:11px;fill:#64748b}</style><text x="360" y="24" text-anchor="middle" class="sc-t sc-title">Structured concurrency: a tree of coroutines</text><rect x="280" y="44" width="160" height="48" rx="8" fill="#7F52FF"/><text x="360" y="73" text-anchor="middle" class="sc-t sc-box">CoroutineScope</text><line x1="320" y1="92" x2="180" y2="135" stroke="#94a3b8" stroke-width="2" marker-end="url(#sc-arr)"/><line x1="360" y1="92" x2="360" y2="135" stroke="#94a3b8" stroke-width="2" marker-end="url(#sc-arr)"/><line x1="400" y1="92" x2="540" y2="135" stroke="#94a3b8" stroke-width="2" marker-end="url(#sc-arr)"/><rect x="100" y="138" width="160" height="44" rx="8" fill="#a78bfa"/><text x="180" y="165" text-anchor="middle" class="sc-t sc-box">child: fetchUser</text><rect x="280" y="138" width="160" height="44" rx="8" fill="#a78bfa"/><text x="360" y="165" text-anchor="middle" class="sc-t sc-box">child: fetchFeed</text><rect x="460" y="138" width="160" height="44" rx="8" fill="#a78bfa"/><text x="540" y="165" text-anchor="middle" class="sc-t sc-box">child: fetchAds</text><line x1="360" y1="182" x2="290" y2="220" stroke="#94a3b8" stroke-width="2" marker-end="url(#sc-arr)"/><line x1="360" y1="182" x2="430" y2="220" stroke="#94a3b8" stroke-width="2" marker-end="url(#sc-arr)"/><rect x="210" y="223" width="160" height="44" rx="8" fill="#c4b5fd"/><text x="290" y="250" text-anchor="middle" class="sc-t sc-box" style="fill:#1e293b">grandchild</text><rect x="380" y="223" width="160" height="44" rx="8" fill="#c4b5fd"/><text x="460" y="250" text-anchor="middle" class="sc-t sc-box" style="fill:#1e293b">grandchild</text><text x="360" y="290" text-anchor="middle" class="sc-t sc-label">Cancel the scope → the whole subtree is cancelled. The scope waits for all children before completing.</text></svg>
+      <br><br>
+      Two guarantees fall out of this tree, and they eliminate whole classes of bugs:
+      <br><br>
+      • <strong>Cancel the parent, cancel the children.</strong> When a user leaves a screen and its scope is cancelled, every coroutine launched there — and their children — is cancelled automatically. No orphaned background task crashing on a dead screen.<br>
+      • <strong>The parent waits for its children.</strong> A scope does not complete until all coroutines inside it finish. No silent leaks of work you forgot about.<br><br>
+      The everyday tool is <code>coroutineScope { }</code>, which creates a scope that only returns once everything inside it is done. Its sibling <code>supervisorScope { }</code> changes one rule: in a plain scope, if one child fails the others are cancelled; in a supervisor scope, children fail independently. You pick based on whether the tasks are "all or nothing" or genuinely independent.
+      <br><br>
+      On Android, you rarely create scopes by hand — the framework provides lifecycle-aware ones like <code>viewModelScope</code> and <code>lifecycleScope</code> that are cancelled automatically when the ViewModel is cleared or the screen is destroyed. Structured concurrency is what makes that automatic cleanup possible.
+
+  - id: cancellation-and-exceptions
+    title: "Cancellation is cooperative"
+    summary: |
+      Cancellation in coroutines is <strong>cooperative</strong>, not forceful. Kotlin will not violently kill a coroutine mid-instruction — that would risk leaving data in a broken state. Instead, cancellation sets a flag, and the coroutine is expected to <em>notice</em> and stop.
+      <br><br>
+      Every suspending function in <code>kotlinx.coroutines</code> checks for cancellation. So a coroutine that regularly suspends (with <code>delay</code>, <code>withContext</code>, network calls, etc.) cancels promptly and cleanly. The mechanism is an exception: cancellation throws a special <code>CancellationException</code> that unwinds the coroutine.
+      <br><br>
+      <pre><code>val job = scope.launch {&#10;    repeat(1000) { i -&gt;&#10;        delay(100)        // a suspension point — checks for cancellation&#10;        println("working $i")&#10;    }&#10;}&#10;delay(350)&#10;job.cancel()              // after ~3 iterations, the next delay() throws</code></pre>
+      <strong>The famous trap.</strong> A coroutine doing tight CPU work that <em>never suspends</em> cannot be cancelled — there is no point at which it checks the flag. It will run to completion regardless of <code>cancel()</code>.
+      <br><br>
+      <pre><code>// BAD: this loop ignores cancellation entirely&#10;launch {&#10;    var i = 0&#10;    while (i &lt; 1_000_000) { heavyCompute(i++) }  // never suspends&#10;}&#10;&#10;// GOOD: give it a chance to notice&#10;launch {&#10;    var i = 0&#10;    while (i &lt; 1_000_000 &amp;&amp; isActive) {   // check the flag&#10;        heavyCompute(i++)&#10;    }&#10;    // or call yield() / ensureActive() periodically&#10;}</code></pre>
+      Two more rules that catch people out. First: never swallow a <code>CancellationException</code> in a blanket <code>catch (e: Exception)</code> — if you do, you break cancellation, because that exception is how cancellation travels. Rethrow it. Second: if you must run cleanup that itself suspends (closing a connection, say) after cancellation, wrap it in <code>withContext(NonCancellable)</code> so the cleanup is allowed to finish.
+
+  - id: introducing-flow
+    title: "Flow — streams of values over time"
+    summary: |
+      A <code>suspend</code> function produces <em>one</em> value, eventually. But plenty of problems involve a <em>sequence</em> of values arriving over time: search results as the user types, rows streaming from a database, price ticks, location updates. Kotlin's answer is <strong>Flow</strong> — an asynchronous stream built on coroutines.
+      <br><br>
+      <pre><code>fun searchResults(query: String): Flow&lt;Result&gt; = flow {&#10;    val pages = api.search(query)        // can suspend&#10;    for (page in pages) {&#10;        emit(page)                        // push each value downstream&#10;        delay(50)&#10;    }&#10;}&#10;&#10;// Consume it — collect is itself a suspend function&#10;searchResults("kotlin").collect { result -&gt;&#10;    display(result)&#10;}</code></pre>
+      The defining property of a basic <code>Flow</code> is that it is <strong>cold</strong>. The code inside the <code>flow { }</code> builder does not run when you create the flow — it runs only when something calls a <em>terminal operator</em> like <code>collect</code>, and it runs again, from scratch, for every collector. A cold flow is a recipe, not a running process.
+      <br><br>
+      It helps to place Flow among its relatives:
+      <br><br>
+      • <strong><code>Sequence</code></strong> — lazy but <em>synchronous</em>: it cannot suspend, so it is for in-memory computation, not waiting on I/O.<br>
+      • <strong><code>Flow</code></strong> — lazy and <em>asynchronous</em>: it can suspend, and it is cold by default.<br>
+      • <strong><code>Channel</code></strong> — a <em>hot</em> pipe between coroutines, like a queue; each value is received by exactly one consumer.<br><br>
+      Flow carries a rich operator library — <code>map</code>, <code>filter</code>, <code>transform</code>, <code>debounce</code>, <code>combine</code>, <code>flatMapLatest</code> — that will feel familiar if you have used RxJava, but built natively on suspension and structured concurrency. Operators are themselves cold: chaining them just builds the recipe; nothing runs until collection.
+      <br><br>
+      <pre><code>searchResults(query)&#10;    .debounce(300)              // wait for typing to settle&#10;    .filter { it.score &gt; 0.5 }&#10;    .map { it.title }&#10;    .flowOn(Dispatchers.IO)     // upstream runs on IO&#10;    .collect { showSuggestion(it) }</code></pre>
+
+  - id: hot-flows-stateflow-sharedflow
+    title: "Hot flows: StateFlow and SharedFlow"
+    summary: |
+      Cold flows are perfect for "do this work when asked." But UIs often need the opposite: a value that <em>exists now</em> and that many observers share — the current screen state, a stream of one-off events. For this, Kotlin provides <strong>hot</strong> flows.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 270" role="img" aria-label="Cold flow versus hot flow behaviour" style="max-width: 100%; height: auto;"><style>.hf-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.hf-title{font-size:16px;font-weight:600}.hf-h{font-size:13px;font-weight:700}.hf-desc{font-size:11px;fill:#64748b}.hf-sm{font-size:10px;fill:#fff;font-weight:600}</style><text x="360" y="24" text-anchor="middle" class="hf-t hf-title">Cold vs hot</text><rect x="30" y="44" width="320" height="200" rx="8" fill="#eff6ff" stroke="#0175C2" stroke-width="1.5"/><text x="190" y="68" text-anchor="middle" class="hf-t hf-h" fill="#0175C2">Cold (flow { })</text><text x="190" y="95" text-anchor="middle" class="hf-t hf-desc">Starts producing only when collected</text><text x="190" y="115" text-anchor="middle" class="hf-t hf-desc">Each collector gets its own run</text><rect x="70" y="135" width="100" height="34" rx="6" fill="#0175C2"/><text x="120" y="157" text-anchor="middle" class="hf-t hf-sm">collector A</text><rect x="210" y="135" width="100" height="34" rx="6" fill="#0175C2"/><text x="260" y="157" text-anchor="middle" class="hf-t hf-sm">collector B</text><text x="190" y="195" text-anchor="middle" class="hf-t hf-desc">→ independent streams</text><text x="190" y="222" text-anchor="middle" class="hf-t hf-desc">Like a recipe: re-run per request</text><rect x="370" y="44" width="320" height="200" rx="8" fill="#fdf4ff" stroke="#7F52FF" stroke-width="1.5"/><text x="530" y="68" text-anchor="middle" class="hf-t hf-h" fill="#7F52FF">Hot (StateFlow / SharedFlow)</text><text x="530" y="95" text-anchor="middle" class="hf-t hf-desc">Emits whether or not anyone listens</text><text x="530" y="115" text-anchor="middle" class="hf-t hf-desc">All collectors share the same stream</text><rect x="480" y="132" width="100" height="30" rx="6" fill="#7F52FF"/><text x="530" y="152" text-anchor="middle" class="hf-t hf-sm">source</text><rect x="410" y="185" width="90" height="30" rx="6" fill="#a78bfa"/><text x="455" y="205" text-anchor="middle" class="hf-t hf-sm">collector A</text><rect x="560" y="185" width="90" height="30" rx="6" fill="#a78bfa"/><text x="605" y="205" text-anchor="middle" class="hf-t hf-sm">collector B</text><line x1="510" y1="162" x2="465" y2="185" stroke="#a78bfa" stroke-width="2"/><line x1="550" y1="162" x2="600" y2="185" stroke="#a78bfa" stroke-width="2"/><text x="530" y="234" text-anchor="middle" class="hf-t hf-desc">Like a radio broadcast: one source, many tuned in</text></svg>
+      <br><br>
+      <strong><code>StateFlow</code></strong> is a hot flow that always holds exactly one current value and emits updates when it changes. It is the modern, coroutine-native replacement for Android's older <code>LiveData</code>, and the backbone of state management in a Jetpack Compose app.
+      <br><br>
+      <pre><code>class CounterViewModel {&#10;    private val _count = MutableStateFlow(0)&#10;    val count: StateFlow&lt;Int&gt; = _count.asStateFlow()   // read-only to the UI&#10;&#10;    fun increment() { _count.value++ }&#10;}&#10;&#10;// In the UI: always has a value, re-renders on change&#10;viewModel.count.collect { n -&gt; render(n) }</code></pre>
+      <strong><code>SharedFlow</code></strong> is the more general hot flow, useful for one-off events (a navigation command, a "show snackbar" signal) that should be delivered to whoever is listening but not retained as state. The bridge between cold and hot is <code>stateIn</code> / <code>shareIn</code>, which convert a cold upstream flow into a hot one tied to a scope — the standard pattern for exposing a repository's cold database flow as observable UI state.
+      <br><br>
+      The mental model that ties it all together: a <strong>cold</strong> flow is a recipe you run on demand; a <strong>hot</strong> flow is a live broadcast that exists whether or not anyone is tuned in. Coroutines gave Kotlin a way to <em>pause</em>; Flow gives it a way to <em>stream</em>; hot flows give it a way to <em>share</em>.
+
+  - id: ai-prompts-coroutines
+    title: "AI prompts — coroutines and Flow"
+    summary: |
+      Use these prompts with an AI assistant to go deeper on the ideas in this episode.
+      <br><br>
+      <strong>Prompt 1 — Callbacks to coroutines:</strong>
+      <pre><code>Rewrite this callback-based async code using Kotlin coroutines:&#10;[paste code]&#10;&#10;Show where each call suspends, mark whether the steps run&#10;sequentially or concurrently, and use structured concurrency.</code></pre>
+      <br>
+      <strong>Prompt 2 — Choosing a dispatcher:</strong>
+      <pre><code>For each operation below, tell me which dispatcher it belongs on&#10;(Default, IO, or Main) and why:&#10;[list your operations: network call, JSON parse, UI update, image decode...]&#10;Then show the withContext calls.</code></pre>
+      <br>
+      <strong>Prompt 3 — Cancellation review:</strong>
+      <pre><code>Review this coroutine code for cancellation correctness:&#10;[paste code]&#10;&#10;Flag any tight loops that never suspend, any catch blocks that&#10;swallow CancellationException, and any cleanup that should use&#10;NonCancellable.</code></pre>
+      <br>
+      <strong>Prompt 4 — Cold vs hot flow design:</strong>
+      <pre><code>I'm modelling [screen state / one-off events / a database stream].&#10;Should this be a cold Flow, a StateFlow, or a SharedFlow?&#10;&#10;Explain the trade-offs and show how to expose it from a ViewModel,&#10;including stateIn/shareIn if a cold source is involved.</code></pre>
+
+quiz:
+  title: "Coroutines & Flow — Quiz"
+  description: "Seven questions on suspension, builders, dispatchers, structured concurrency, cancellation, and the cold and hot streams of Flow."
+  questions:
+    - question: "What is the difference between a suspended coroutine and a blocked thread?"
+      options:
+        - "There is no difference; they are two names for the same thing"
+        - "A blocked thread holds its resources idle; a suspended coroutine releases its thread to do other work"
+        - "A suspended coroutine uses more memory than a blocked thread"
+        - "A blocked thread can be cancelled but a suspended coroutine cannot"
+      correctIndex: 1
+      explanation: "A blocked thread sits idle holding ~1 MB of memory until its wait finishes. A suspended coroutine saves its state, releases the thread entirely so it can run other work, and resumes later. That is why millions of coroutines can run on a handful of threads."
+    - question: "How does the Kotlin compiler implement a suspend function under the hood?"
+      options:
+        - "It spawns a new operating-system thread for each call"
+        - "It rewrites the function as a state machine using continuation-passing style"
+        - "It runs the function on the GPU"
+        - "It converts the function into a loop that polls until done"
+      correctIndex: 1
+      explanation: "The compiler adds a hidden Continuation parameter (continuation-passing style) and slices the function into a state machine. Each suspension point is a state; on resume, the machine jumps to the right state with locals restored. This is how a function can pause and resume without blocking a thread."
+    - question: "You write `val a = async { x() }` then `val b = async { y() }`, then `a.await()` and `b.await()`. How do x() and y() run?"
+      options:
+        - "Strictly sequentially, one after the other"
+        - "Concurrently, because both async blocks start before either is awaited"
+        - "Neither runs until the program exits"
+        - "On separate OS processes"
+      correctIndex: 1
+      explanation: "Both async builders start their coroutines immediately, so x() and y() run concurrently; the awaits then suspend until each result is ready. Concurrency comes from starting both before awaiting. If you instead wrote `async { x() }.await()` then `async { y() }.await()`, they would run sequentially."
+    - question: "Which dispatcher is intended for blocking I/O such as network and disk access?"
+      options:
+        - "Dispatchers.Default"
+        - "Dispatchers.Main"
+        - "Dispatchers.IO"
+        - "Dispatchers.Unconfined"
+      correctIndex: 2
+      explanation: "Dispatchers.IO has a large, elastic thread pool designed for blocking I/O (network, disk, database). Dispatchers.Default is sized to CPU cores for CPU-intensive work, and Dispatchers.Main is the single UI thread."
+    - question: "Under structured concurrency, what happens to child coroutines when their parent scope is cancelled?"
+      options:
+        - "They keep running until they finish on their own"
+        - "They are all cancelled automatically"
+        - "They are paused and resumed later"
+        - "Only the most recently launched child is cancelled"
+      correctIndex: 1
+      explanation: "Coroutines form a parent-child tree within a scope. Cancelling the scope cancels every coroutine in its subtree automatically, and a scope will not complete until all its children finish. This prevents orphaned background tasks and leaks."
+    - question: "Why might a coroutine running a tight CPU loop fail to cancel?"
+      options:
+        - "Cancellation only works on the Main dispatcher"
+        - "Cancellation is cooperative, and a loop that never suspends never checks the cancellation flag"
+        - "CPU loops automatically disable cancellation"
+        - "You can never cancel a coroutine once it has started"
+      correctIndex: 1
+      explanation: "Cancellation is cooperative: it sets a flag that suspending functions check. A tight loop that never suspends (no delay, yield, isActive check, etc.) never notices the flag and runs to completion. The fix is to check isActive or call yield()/ensureActive() periodically."
+    - question: "What does it mean that a basic Flow is 'cold'?"
+      options:
+        - "It can only carry numeric values"
+        - "It runs on a background thread by default"
+        - "Its builder code runs only when collected, and runs fresh for each collector"
+        - "It retains its last value forever for new subscribers"
+      correctIndex: 2
+      explanation: "A cold Flow is like a recipe: the code in the flow { } builder runs only when a terminal operator such as collect subscribes, and it runs again from scratch for each collector. Hot flows (StateFlow, SharedFlow) instead emit whether or not anyone is listening and share the stream among collectors."
+---
+
+{/* Episode 1 of Kotlin: Concurrency. Deep dive on coroutines and Flow: the
+    callback pyramid, suspend vs blocking, the CPS/state-machine compilation,
+    launch/async/runBlocking builders, dispatchers and withContext, structured
+    concurrency, cooperative cancellation, cold Flow, and hot StateFlow/SharedFlow.
+    Six inline SVG diagrams. */}

--- a/src/content/deep-dives/kotlin.mdx
+++ b/src/content/deep-dives/kotlin.mdx
@@ -1,0 +1,218 @@
+---
+title: "Why Kotlin Exists — Frustration, an Island, and a Better JVM"
+description: "How a team tired of writing Java built a language on an island near Saint Petersburg, won over Google and Android, and made concurrency a joy with coroutines. The origin story behind the language."
+category: "Kotlin"
+color: "#7F52FF"
+subject: "Kotlin: Foundations"
+order: 1
+publishedAt: 2026-06-04
+topics:
+  - id: the-problem-with-java
+    title: "The problem with Java"
+    summary: |
+      Most languages are born from frustration. Kotlin is no exception.
+      <br><br>
+      In 2010, JetBrains had a problem that few companies share: they wrote tools for programmers for a living, and they wrote them in Java. IntelliJ IDEA — their flagship product — was a sprawling codebase of millions of lines of Java. Every day, their own engineers felt Java's friction firsthand. The endless <code>getters</code> and <code>setters</code>. The ceremony of an anonymous inner class just to pass a single callback. And, lurking everywhere, the dreaded <code>NullPointerException</code>.
+      <br><br>
+      Java was reliable and fast, and the JVM (Java Virtual Machine) it ran on was one of the most battle-tested pieces of software on Earth. But the language itself had calcified. Between Java 6 (2006) and Java 7 (2011), the language barely moved. Sun Microsystems — Java's creator — was being acquired by Oracle, and the language's evolution had slowed to a crawl. Programmers wanted more, and Java wasn't giving it to them.
+      <br><br>
+      JetBrains looked around at the alternatives. The most obvious candidate was <strong>Scala</strong> — a powerful, expressive language that also ran on the JVM and interoperated with Java. Scala had everything Java lacked: type inference, functional programming, concise syntax. The JetBrains team actually liked Scala. But there was a catch that, for a tools company, was fatal.
+      <br><br>
+      <strong>Scala compiled too slowly.</strong> If your entire business is building a fast, responsive IDE, you cannot have your developers waiting on a sluggish compiler all day. And you certainly cannot ask <em>your customers</em> to wait on it. So JetBrains made a decision that sounds slightly mad in hindsight: if no existing language fit, they would build their own.
+      <br><br>
+      The goals were pragmatic, not academic. They didn't want to invent a beautiful new paradigm. They wanted a language that was: <strong>concise</strong> (less boilerplate than Java), <strong>safe</strong> (no more random null crashes), <strong>interoperable</strong> (call Java seamlessly, because rewriting IntelliJ from scratch was out of the question), and — critically — <strong>fast to compile</strong>.
+
+  - id: an-island-named-kotlin
+    title: "An island named Kotlin"
+    summary: |
+      Every language needs a name. Java was named after the Indonesian island famous for its coffee — which is why its logo is a steaming cup and why so much Java code lives in packages full of "beans". JetBrains decided to honour that tradition, with a twist closer to home.
+      <br><br>
+      They named the language <strong>Kotlin</strong>, after <strong>Kotlin Island</strong> — a small island in the Gulf of Finland, just off the coast of Saint Petersburg, Russia, where JetBrains' development team was based. The logic was charming: "Java is named after an island, so we'll name ours after an island too." The island is home to the town of Kronstadt and has guarded the sea approach to Saint Petersburg since the days of Peter the Great.
+      <br><br>
+      The language was first announced publicly in <strong>July 2011</strong> by Andrey Breslav, Kotlin's lead language designer, at a JVM Language Summit. The reaction was lukewarm — the world had plenty of "better Java" projects, and most went nowhere. In <strong>February 2012</strong>, JetBrains open-sourced Kotlin under the Apache 2 licence, a deliberate signal that this was not a proprietary toy but a language meant to be trusted and adopted widely.
+      <br><br>
+      Then came years of patient, unglamorous work. Version <strong>1.0</strong> — the first release JetBrains promised to support long-term — did not arrive until <strong>February 2016</strong>. Five years from announcement to 1.0. That slow burn is itself a piece of Kotlin's character: it was designed by people who maintained enormous codebases and knew that stability matters more than novelty.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 260" role="img" aria-label="Kotlin history timeline from 2010 to 2019" style="max-width: 100%; height: auto;"><style>.kt-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.kt-title{font-size:16px;font-weight:600}.kt-year{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:14px;font-weight:700;fill:#7F52FF}.kt-label{font-size:11px;fill:#475569}</style><text x="360" y="26" text-anchor="middle" class="kt-t kt-title">A slow burn: Kotlin's first decade</text><line x1="50" y1="120" x2="670" y2="120" stroke="#cbd5e1" stroke-width="3"/><g><circle cx="70" cy="120" r="7" fill="#7F52FF"/><text x="70" y="100" text-anchor="middle" class="kt-t kt-year">2010</text><text x="70" y="150" text-anchor="middle" class="kt-t kt-label">JetBrains</text><text x="70" y="165" text-anchor="middle" class="kt-t kt-label">starts work</text></g><g><circle cx="190" cy="120" r="7" fill="#7F52FF"/><text x="190" y="100" text-anchor="middle" class="kt-t kt-year">2011</text><text x="190" y="150" text-anchor="middle" class="kt-t kt-label">Announced</text><text x="190" y="165" text-anchor="middle" class="kt-t kt-label">publicly</text></g><g><circle cx="310" cy="120" r="7" fill="#7F52FF"/><text x="310" y="100" text-anchor="middle" class="kt-t kt-year">2016</text><text x="310" y="150" text-anchor="middle" class="kt-t kt-label">Version 1.0</text><text x="310" y="165" text-anchor="middle" class="kt-t kt-label">released</text></g><g><circle cx="430" cy="120" r="7" fill="#10b981"/><text x="430" y="100" text-anchor="middle" class="kt-t kt-year">2017</text><text x="430" y="150" text-anchor="middle" class="kt-t kt-label">Google adds</text><text x="430" y="165" text-anchor="middle" class="kt-t kt-label">Android support</text></g><g><circle cx="550" cy="120" r="7" fill="#7F52FF"/><text x="550" y="100" text-anchor="middle" class="kt-t kt-year">2018</text><text x="550" y="150" text-anchor="middle" class="kt-t kt-label">Coroutines</text><text x="550" y="165" text-anchor="middle" class="kt-t kt-label">stable (1.3)</text></g><g><circle cx="660" cy="120" r="7" fill="#10b981"/><text x="660" y="100" text-anchor="middle" class="kt-t kt-year">2019</text><text x="660" y="150" text-anchor="middle" class="kt-t kt-label">Android goes</text><text x="660" y="165" text-anchor="middle" class="kt-t kt-label">"Kotlin-first"</text></g></svg>
+      <br><br>
+      Andrey Breslav led the language design until 2020, when Roman Elizarov — the engineer most associated with Kotlin's coroutines — took over as project lead. The torch passing from a language designer to a concurrency expert is itself a hint about where Kotlin's centre of gravity had moved.
+
+  - id: pragmatic-by-design
+    title: "Pragmatic by design"
+    summary: |
+      Kotlin's designers have a favourite word: <strong>pragmatic</strong>. They were not trying to win academic arguments. They were trying to make working programmers faster and their programs safer. Every feature was weighed against a simple test: does this help people who ship real software?
+      <br><br>
+      The clearest demonstration is the humble <strong>data class</strong>. In Java, modelling a simple "user with a name and age" means writing a constructor, two getters, <code>equals()</code>, <code>hashCode()</code>, and <code>toString()</code> — dozens of lines of mechanical, error-prone boilerplate. In Kotlin, it is one line.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" role="img" aria-label="Java verbosity versus Kotlin conciseness for a simple data class" style="max-width: 100%; height: auto;"><style>.kc-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.kc-title{font-size:16px;font-weight:600}.kc-h{font-size:13px;font-weight:700}.kc-code{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:10px;fill:#475569}.kc-note{font-size:12px;fill:#64748b}</style><text x="360" y="24" text-anchor="middle" class="kc-t kc-title">Same data model — Java vs Kotlin</text><rect x="30" y="45" width="320" height="210" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" rx="8"/><text x="50" y="68" class="kc-t kc-h" fill="#dc2626">Java — ~20 lines</text><text x="48" y="92" class="kc-t kc-code">class User {</text><text x="48" y="108" class="kc-t kc-code">&#160;&#160;private final String name;</text><text x="48" y="124" class="kc-t kc-code">&#160;&#160;private final int age;</text><text x="48" y="140" class="kc-t kc-code">&#160;&#160;User(String n, int a) {…}</text><text x="48" y="156" class="kc-t kc-code">&#160;&#160;String getName() {…}</text><text x="48" y="172" class="kc-t kc-code">&#160;&#160;int getAge() {…}</text><text x="48" y="188" class="kc-t kc-code">&#160;&#160;boolean equals(Object o) {…}</text><text x="48" y="204" class="kc-t kc-code">&#160;&#160;int hashCode() {…}</text><text x="48" y="220" class="kc-t kc-code">&#160;&#160;String toString() {…}</text><text x="48" y="236" class="kc-t kc-code">}</text><rect x="380" y="45" width="310" height="210" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5" rx="8"/><text x="400" y="68" class="kc-t kc-h" fill="#7F52FF">Kotlin — 1 line</text><text x="398" y="120" class="kc-t kc-code" style="font-size:12px;fill:#1e293b">data class User(</text><text x="398" y="140" class="kc-t kc-code" style="font-size:12px;fill:#1e293b">&#160;&#160;val name: String,</text><text x="398" y="160" class="kc-t kc-code" style="font-size:12px;fill:#1e293b">&#160;&#160;val age: Int</text><text x="398" y="180" class="kc-t kc-code" style="font-size:12px;fill:#1e293b">)</text><text x="535" y="225" text-anchor="middle" class="kc-t kc-note">equals, hashCode,</text><text x="535" y="242" text-anchor="middle" class="kc-t kc-note">toString — all generated</text></svg>
+      <br><br>
+      The <code>data</code> keyword tells the compiler to generate <code>equals()</code>, <code>hashCode()</code>, <code>toString()</code>, and a <code>copy()</code> method automatically. Notice also <code>val</code> — Kotlin's keyword for an immutable, read-only reference (its mutable sibling is <code>var</code>). Immutability is the default you reach for; mutability is opt-in. That single choice quietly eliminates a whole category of bugs.
+      <br><br>
+      Conciseness is not the only pillar. Kotlin's design rests on a few deliberate decisions:
+      <br><br>
+      • <strong>Interoperability first.</strong> Kotlin can call any Java library and Java can call Kotlin. This was non-negotiable — it meant teams could adopt Kotlin one file at a time, never rewriting everything.<br>
+      • <strong>Tooling as a feature.</strong> JetBrains builds IDEs; Kotlin was designed alongside its tooling, so autocomplete, refactoring, and Java-to-Kotlin conversion were first-class from day one.<br>
+      • <strong>No surprises.</strong> Kotlin avoids "clever" features that make code hard to read. It is expressive, but it deliberately stops short of Scala's full power in exchange for being easier to learn and faster to compile.
+
+  - id: the-null-story
+    title: "The null story, revisited"
+    summary: |
+      If you have read the Dart series, you already know the villain of this section. In 1965, the British computer scientist <strong>Tony Hoare</strong> invented the null reference for the ALGOL W language. Decades later he publicly apologised for it, calling null his <strong>"billion-dollar mistake"</strong> — because null reference errors have caused more crashes than perhaps any other single feature in the history of programming.
+      <br><br>
+      Java inherited null wholesale, and with it the infamous <code>NullPointerException</code>. Kotlin's answer is the same elegant idea Dart later adopted: <strong>make nullability part of the type</strong>. By default, a Kotlin type cannot hold null. To allow it, you add a <code>?</code>.
+      <br><br>
+      <pre><code>var name: String = "Ankit"&#10;name = null          // compile error — String cannot be null&#10;&#10;var nickname: String? = "Ank"&#10;nickname = null      // fine — String? allows null</code></pre>
+      Once a type is nullable, the compiler refuses to let you use it carelessly. To work with nullable values, Kotlin gives you a small, memorable toolkit of operators — and the names behind them are a fun slice of programming folklore.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 250" role="img" aria-label="Kotlin null-handling operators" style="max-width: 100%; height: auto;"><style>.kn-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.kn-title{font-size:16px;font-weight:600}.kn-op{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:20px;font-weight:700;fill:#7F52FF}.kn-name{font-size:12px;font-weight:600;fill:#1e293b}.kn-desc{font-size:11px;fill:#64748b}.kn-ex{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:10px;fill:#475569}</style><text x="360" y="26" text-anchor="middle" class="kn-t kn-title">Kotlin's null toolkit</text><rect x="30" y="50" width="200" height="130" fill="#f5f3ff" stroke="#7F52FF" stroke-width="2" rx="8"/><text x="130" y="85" text-anchor="middle" class="kn-t kn-op">?.</text><text x="130" y="110" text-anchor="middle" class="kn-t kn-name">safe call</text><text x="130" y="132" text-anchor="middle" class="kn-t kn-desc">returns null instead</text><text x="130" y="146" text-anchor="middle" class="kn-t kn-desc">of crashing</text><text x="130" y="168" text-anchor="middle" class="kn-t kn-ex">name?.length</text><rect x="255" y="50" width="200" height="130" fill="#ecfdf5" stroke="#10b981" stroke-width="2" rx="8"/><text x="355" y="85" text-anchor="middle" class="kn-t kn-op">?:</text><text x="355" y="110" text-anchor="middle" class="kn-t kn-name">Elvis operator</text><text x="355" y="132" text-anchor="middle" class="kn-t kn-desc">supplies a default</text><text x="355" y="146" text-anchor="middle" class="kn-t kn-desc">when left is null</text><text x="355" y="168" text-anchor="middle" class="kn-t kn-ex">name ?: "Guest"</text><rect x="480" y="50" width="210" height="130" fill="#fef2f2" stroke="#dc2626" stroke-width="2" rx="8"/><text x="585" y="85" text-anchor="middle" class="kn-t kn-op">!!</text><text x="585" y="110" text-anchor="middle" class="kn-t kn-name">not-null assertion</text><text x="585" y="132" text-anchor="middle" class="kn-t kn-desc">"trust me" — crashes</text><text x="585" y="146" text-anchor="middle" class="kn-t kn-desc">with NPE if wrong</text><text x="585" y="168" text-anchor="middle" class="kn-t kn-ex">name!!.length</text><text x="360" y="215" text-anchor="middle" class="kn-t kn-desc">The Elvis operator ?: is so named because, rotated 90°, it looks like Elvis Presley's hair and eyes.</text></svg>
+      <br><br>
+      The <strong>Elvis operator</strong> <code>?:</code> earned its name because, tilted on its side, the <code>?</code> and <code>:</code> resemble Elvis Presley's iconic quiff and eyes. It supplies a fallback: <code>val len = name?.length ?: 0</code> reads as "the length, or zero if name is null." The double-bang <code>!!</code> is sometimes called the <strong>"shouting" operator</strong> — it loudly insists a value is not null, and if you are wrong, it throws the very <code>NullPointerException</code> you were trying to avoid. Seasoned Kotlin developers treat <code>!!</code> as a code smell.
+      <br><br>
+      Kotlin also has a trick Dart lacks the equivalent pressure for: <strong>smart casts</strong>. Once you check that a value is not null, the compiler "promotes" it and lets you use it as non-null without ceremony.
+      <br><br>
+      <pre><code>fun greet(name: String?) {&#10;    if (name != null) {&#10;        // smart cast: name is now treated as String, not String?&#10;        println(name.uppercase())&#10;    }&#10;}</code></pre>
+      <strong>The interop gotcha.</strong> Here is where Kotlin's null safety meets the messy real world. When Kotlin calls a Java method, the compiler often cannot know whether Java will return null — Java's types carry no such information. Kotlin calls these <strong>platform types</strong>, written internally as <code>String!</code> (with a single bang). They are an escape hatch: Kotlin trusts you to handle them correctly. It is the one place where Kotlin's otherwise airtight null safety has a deliberate leak — the price of seamless Java interoperability.
+
+  - id: google-android-2017
+    title: "Google, Android, and the 2017 moment"
+    summary: |
+      For its first five years, Kotlin was a respected niche language with a devoted following. Then, in May 2017, everything changed in a single announcement.
+      <br><br>
+      At <strong>Google I/O 2017</strong>, Google announced first-class support for Kotlin on Android. For the millions of developers building Android apps — who had been stuck writing Java, and an old dialect of Java at that — this was electrifying. Android's Java was frozen at a roughly Java 7/8 level for compatibility reasons, meaning Android developers were missing years of language improvements. Kotlin instantly handed them everything they had been craving: null safety, concise syntax, lambdas, extension functions.
+      <br><br>
+      There was also a strategic subtext. Around the same time, Oracle and Google were locked in a long, bitter lawsuit over Google's use of the Java APIs in Android — a case that would eventually reach the U.S. Supreme Court. Kotlin, with its open-source Apache licence and independent steward in JetBrains, offered Google a path that did not depend so heavily on Oracle's Java. Whatever the mix of technical love and legal caution, the effect was the same: Kotlin's adoption exploded.
+      <br><br>
+      Two years later, at Google I/O 2019, Google went further and declared Android development <strong>"Kotlin-first"</strong> — meaning new APIs, documentation, and samples would prioritise Kotlin over Java. For a language that started as one company's internal frustration, becoming the preferred language of the world's most popular operating system was a staggering arc.
+      <br><br>
+      The lesson is worth pausing on: Kotlin's <em>interoperability</em> — that non-negotiable design pillar from the start — is exactly what made this possible. Because Kotlin and Java run on the same JVM and call each other freely, an Android team could adopt Kotlin one screen, one file, even one line at a time. No big rewrite, no risky migration. That gradual on-ramp, more than any single feature, is why Kotlin won.
+
+  - id: compiles-to-everything
+    title: "Compiles to everything"
+    summary: |
+      Kotlin began as a JVM language, but it did not stay confined to the JVM. Today the same Kotlin source can be compiled to run almost anywhere — a flexibility that powers <strong>Kotlin Multiplatform</strong>, where shared business logic is written once and run on many platforms.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" role="img" aria-label="Kotlin compilation targets: JVM, Native, JavaScript and WebAssembly" style="max-width: 100%; height: auto;"><defs><marker id="kt-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#7F52FF"/></marker></defs><style>.kp-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.kp-title{font-size:16px;font-weight:600}.kp-h{font-family:"SF Mono",Menlo,Monaco,monospace;font-size:14px;font-weight:700;fill:#fff}.kp-name{font-size:13px;font-weight:700;fill:#1e293b}.kp-desc{font-size:11px;fill:#64748b}</style><text x="360" y="26" text-anchor="middle" class="kp-t kp-title">One language, many targets</text><rect x="290" y="48" width="140" height="56" rx="10" fill="#7F52FF"/><text x="360" y="82" text-anchor="middle" class="kp-t kp-h">.kt source</text><line x1="360" y1="104" x2="120" y2="150" stroke="#7F52FF" stroke-width="2" marker-end="url(#kt-arr)"/><line x1="360" y1="104" x2="280" y2="150" stroke="#7F52FF" stroke-width="2" marker-end="url(#kt-arr)"/><line x1="360" y1="104" x2="440" y2="150" stroke="#7F52FF" stroke-width="2" marker-end="url(#kt-arr)"/><line x1="360" y1="104" x2="600" y2="150" stroke="#7F52FF" stroke-width="2" marker-end="url(#kt-arr)"/><g transform="translate(40,155)"><rect x="0" y="0" width="160" height="120" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5"/><text x="80" y="30" text-anchor="middle" class="kp-t kp-name">Kotlin/JVM</text><text x="80" y="58" text-anchor="middle" class="kp-t kp-desc">JVM bytecode</text><text x="80" y="76" text-anchor="middle" class="kp-t kp-desc">Android, servers,</text><text x="80" y="92" text-anchor="middle" class="kp-t kp-desc">desktop</text><text x="80" y="110" text-anchor="middle" class="kp-t kp-desc">the original target</text></g><g transform="translate(210,155)"><rect x="0" y="0" width="150" height="120" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5"/><text x="75" y="30" text-anchor="middle" class="kp-t kp-name">Kotlin/Native</text><text x="75" y="58" text-anchor="middle" class="kp-t kp-desc">LLVM → native</text><text x="75" y="76" text-anchor="middle" class="kp-t kp-desc">binaries</text><text x="75" y="92" text-anchor="middle" class="kp-t kp-desc">iOS, embedded,</text><text x="75" y="108" text-anchor="middle" class="kp-t kp-desc">no JVM needed</text></g><g transform="translate(370,155)"><rect x="0" y="0" width="150" height="120" rx="8" fill="#f5f3ff" stroke="#7F52FF" stroke-width="1.5"/><text x="75" y="30" text-anchor="middle" class="kp-t kp-name">Kotlin/JS</text><text x="75" y="58" text-anchor="middle" class="kp-t kp-desc">JavaScript</text><text x="75" y="76" text-anchor="middle" class="kp-t kp-desc">runs in the</text><text x="75" y="92" text-anchor="middle" class="kp-t kp-desc">browser / Node</text></g><g transform="translate(530,155)"><rect x="0" y="0" width="150" height="120" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/><text x="75" y="30" text-anchor="middle" class="kp-t kp-name">Kotlin/Wasm</text><text x="75" y="58" text-anchor="middle" class="kp-t kp-desc">WebAssembly</text><text x="75" y="76" text-anchor="middle" class="kp-t kp-desc">near-native speed</text><text x="75" y="92" text-anchor="middle" class="kp-t kp-desc">in the browser</text><text x="75" y="108" text-anchor="middle" class="kp-t kp-desc">the newest target</text></g></svg>
+      <br><br>
+      <strong>Kotlin/JVM</strong> is the original: your code compiles to Java bytecode and runs on any JVM — Android, backend servers, desktop apps. <strong>Kotlin/Native</strong> uses the LLVM compiler toolchain to produce standalone native binaries with no JVM at all, which is how Kotlin reaches iOS and embedded devices. <strong>Kotlin/JS</strong> transpiles to JavaScript for the browser, and the newer <strong>Kotlin/Wasm</strong> targets WebAssembly for near-native speed on the web.
+      <br><br>
+      This is the same "write once" promise that Flutter and Dart make, approached from a different angle. Where Flutter ships its own rendering engine, Kotlin Multiplatform typically shares only the logic layer and lets each platform keep its native UI. Two philosophies, both chasing the same dream of not writing the same code three times.
+
+  - id: kotlins-superpower-coroutines
+    title: "Kotlin's superpower: coroutines"
+    summary: |
+      If null safety is the feature that first attracts people to Kotlin, <strong>coroutines</strong> are the feature that makes them stay. Coroutines are Kotlin's answer to one of the hardest problems in programming: how to write code that waits — for a network request, a database, a file — without freezing your program or drowning in callbacks.
+      <br><br>
+      The idea is old. It traces back to <strong>Communicating Sequential Processes (CSP)</strong>, a model described by Tony Hoare (yes, the same Hoare) in 1978. It echoes the <code>async</code>/<code>await</code> that C# popularised, and the lightweight "goroutines" of the Go language. Kotlin's team — led on this front by <strong>Roman Elizarov</strong> — synthesised these ideas into something that felt native to the language. Coroutines arrived experimentally in Kotlin 1.1 (2017) and became stable in <strong>Kotlin 1.3, in October 2018</strong>.
+      <br><br>
+      The core insight is the <code>suspend</code> keyword. A suspending function can <em>pause</em> partway through and <em>resume</em> later, without blocking the thread it was running on. While it waits, the thread is free to do other work.
+      <br><br>
+      <pre><code>suspend fun loadUser(): User {&#10;    val profile = fetchProfile()   // suspends here, thread is free&#10;    val photo = fetchPhoto()       // suspends again&#10;    return User(profile, photo)&#10;}</code></pre>
+      Why does this matter so much? Because the traditional unit of concurrency — the <strong>thread</strong> — is expensive. Each thread reserves about a megabyte of memory and is managed by the operating system. A server might handle a few thousand threads before grinding to a halt. Coroutines are different: they are cheap, managed by Kotlin itself, and you can launch <strong>millions</strong> of them on a handful of threads.
+      <br><br>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 340" role="img" aria-label="Threads versus coroutines: heavy blocked threads compared to many lightweight coroutines on few threads" style="max-width: 100%; height: auto;"><style>.cr-t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,sans-serif;fill:#1e293b}.cr-title{font-size:16px;font-weight:600}.cr-h{font-size:13px;font-weight:700}.cr-label{font-size:11px;fill:#64748b}.cr-sm{font-size:10px;fill:#fff;font-weight:600}</style><text x="360" y="24" text-anchor="middle" class="cr-t cr-title">Threads vs coroutines</text><rect x="20" y="44" width="330" height="280" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" rx="8"/><text x="185" y="68" text-anchor="middle" class="cr-t cr-h" fill="#dc2626">Threads — heavy &amp; blocking</text><g><rect x="50" y="85" width="80" height="60" rx="6" fill="#dc2626"/><text x="90" y="112" text-anchor="middle" class="cr-t cr-sm">Thread 1</text><text x="90" y="128" text-anchor="middle" class="cr-t cr-sm">BLOCKED</text><rect x="145" y="85" width="80" height="60" rx="6" fill="#dc2626"/><text x="185" y="112" text-anchor="middle" class="cr-t cr-sm">Thread 2</text><text x="185" y="128" text-anchor="middle" class="cr-t cr-sm">BLOCKED</text><rect x="240" y="85" width="80" height="60" rx="6" fill="#dc2626"/><text x="280" y="112" text-anchor="middle" class="cr-t cr-sm">Thread 3</text><text x="280" y="128" text-anchor="middle" class="cr-t cr-sm">BLOCKED</text></g><text x="185" y="180" text-anchor="middle" class="cr-t cr-label">~1 MB each · managed by the OS</text><text x="185" y="200" text-anchor="middle" class="cr-t cr-label">Each waits idle while blocked</text><text x="185" y="240" text-anchor="middle" class="cr-t cr-label" style="font-size:13px;fill:#dc2626;font-weight:600">A few thousand max</text><text x="185" y="290" text-anchor="middle" class="cr-t cr-label">Waiting on I/O wastes a whole thread</text><rect x="370" y="44" width="330" height="280" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5" rx="8"/><text x="535" y="68" text-anchor="middle" class="cr-t cr-h" fill="#10b981">Coroutines — light &amp; suspending</text><g><rect x="400" y="85" width="120" height="40" rx="6" fill="#10b981"/><text x="460" y="110" text-anchor="middle" class="cr-t cr-sm">Thread A</text><rect x="550" y="85" width="120" height="40" rx="6" fill="#10b981"/><text x="610" y="110" text-anchor="middle" class="cr-t cr-sm">Thread B</text></g><g fill="#7F52FF"><circle cx="410" cy="150" r="8"/><circle cx="435" cy="150" r="8"/><circle cx="460" cy="150" r="8"/><circle cx="485" cy="150" r="8"/><circle cx="510" cy="150" r="8"/><circle cx="560" cy="150" r="8"/><circle cx="585" cy="150" r="8"/><circle cx="610" cy="150" r="8"/><circle cx="635" cy="150" r="8"/><circle cx="660" cy="150" r="8"/><circle cx="410" cy="172" r="8"/><circle cx="435" cy="172" r="8"/><circle cx="460" cy="172" r="8"/><circle cx="485" cy="172" r="8"/><circle cx="510" cy="172" r="8"/><circle cx="560" cy="172" r="8"/><circle cx="585" cy="172" r="8"/><circle cx="610" cy="172" r="8"/><circle cx="635" cy="172" r="8"/><circle cx="660" cy="172" r="8"/></g><text x="535" y="205" text-anchor="middle" class="cr-t cr-label">Each suspends &amp; resumes — frees the thread</text><text x="535" y="240" text-anchor="middle" class="cr-t cr-label" style="font-size:13px;fill:#10b981;font-weight:600">Millions, on a few threads</text><text x="535" y="290" text-anchor="middle" class="cr-t cr-label">While one waits, the thread runs another</text></svg>
+      <br><br>
+      Kotlin's other great contribution here is <strong>structured concurrency</strong>. Coroutines are launched inside a <code>CoroutineScope</code>, forming a parent-child tree. If the parent is cancelled — say, the user leaves the screen — all its children are cancelled automatically. If one child fails, its siblings can be cancelled too. This sounds mundane, but it eliminates a classic bug: the orphaned background task that keeps running, leaking memory and crashing on a screen that no longer exists.
+      <br><br>
+      <pre><code>// launch fires off work that returns nothing&#10;scope.launch { saveToDatabase() }&#10;&#10;// async returns a value you can await&#10;val deferred = scope.async { computeResult() }&#10;val result = deferred.await()</code></pre>
+      <strong>Two famous gotchas.</strong> First: <code>suspend</code> does <em>not</em> mean "run in parallel." A suspending function runs sequentially by default — the two <code>fetch</code> calls above happen one after another. To run them concurrently you must explicitly use <code>async</code> and <code>await</code> both. Second: because cancellation is cooperative, a coroutine stuck in a tight CPU loop that never suspends cannot be cancelled. You have to give it a chance to check, which is why coroutine code sprinkles in <code>yield()</code> or checks <code>isActive</code>.
+
+  - id: flow-cold-streams
+    title: "Flow — cold streams done right"
+    summary: |
+      A single <code>suspend</code> function returns one value. But programs often deal with <em>streams</em> of values over time: location updates, search results as you type, rows arriving from a database. Kotlin's answer is <strong>Flow</strong> — a coroutine-native, asynchronous stream.
+      <br><br>
+      <pre><code>fun temperatures(): Flow&lt;Int&gt; = flow {&#10;    while (true) {&#10;        emit(readSensor())   // push a value&#10;        delay(1000)          // wait a second (suspends)&#10;    }&#10;}&#10;&#10;// nothing happens until someone collects&#10;temperatures().collect { temp -&gt; println(temp) }</code></pre>
+      The crucial property is that a basic <code>Flow</code> is <strong>cold</strong>. The code inside the <code>flow { }</code> builder does not run when you create the flow — it runs only when something <code>collect</code>s it, and it runs fresh for each collector. This is the opposite of a <strong>hot</strong> stream (like <code>SharedFlow</code> or a <code>Channel</code>), which produces values whether or not anyone is listening, and shares them among collectors.
+      <br><br>
+      It helps to place Flow among its relatives:
+      <br><br>
+      • <strong><code>Sequence</code></strong> — lazy, but <em>synchronous</em>. It cannot suspend, so it is for in-memory computation, not waiting on I/O.<br>
+      • <strong><code>Flow</code></strong> — lazy and <em>asynchronous</em>. It can suspend with <code>delay</code> or network calls. Cold by default.<br>
+      • <strong><code>Channel</code></strong> — a hot pipe between coroutines, like a queue; values are consumed once.<br><br>
+      Flow comes with a rich library of operators — <code>map</code>, <code>filter</code>, <code>debounce</code>, <code>combine</code> — that should feel familiar to anyone who has used reactive streams like RxJava, but built natively on coroutines and structured concurrency. It is the foundation of modern reactive Kotlin, and the natural subject for the next episode in this series. Coroutines gave Kotlin a way to <em>pause</em>; Flow gives it a way to <em>stream</em>.
+
+  - id: ai-prompts-kotlin
+    title: "AI prompts — exploring Kotlin"
+    summary: |
+      Use these prompts with an AI assistant to go deeper on the ideas in this episode.
+      <br><br>
+      <strong>Prompt 1 — Java to Kotlin, idiomatically:</strong>
+      <pre><code>Convert this Java class to idiomatic Kotlin:&#10;[paste Java code]&#10;&#10;Use data classes, val/var appropriately, null-safe types,&#10;and explain each idiom you applied and why.</code></pre>
+      <br>
+      <strong>Prompt 2 — Null safety patterns:</strong>
+      <pre><code>Review this Kotlin code for null-safety smells:&#10;[paste code]&#10;&#10;Flag every !! operator, suggest safer alternatives using ?., ?:,&#10;or smart casts, and point out any platform types coming from Java&#10;that I'm not handling.</code></pre>
+      <br>
+      <strong>Prompt 3 — Coroutines vs threads:</strong>
+      <pre><code>Explain how this blocking, thread-based code would be rewritten&#10;with Kotlin coroutines:&#10;[paste code]&#10;&#10;Show me where it suspends, whether the work runs sequentially or&#10;concurrently, and how structured concurrency handles cancellation.</code></pre>
+      <br>
+      <strong>Prompt 4 — Cold vs hot streams:</strong>
+      <pre><code>I have a stream of [search results / sensor readings / UI events].&#10;Should I model it as a cold Flow, a SharedFlow, or a Channel?&#10;&#10;Walk through the trade-offs for my case, and show the code for&#10;the option you recommend.</code></pre>
+
+quiz:
+  title: "Why Kotlin Exists — Quiz"
+  description: "Seven questions on Kotlin's origins, its null safety, compilation targets, and the coroutines and Flow that define it."
+  questions:
+    - question: "Why did JetBrains create Kotlin instead of adopting Scala?"
+      options:
+        - "Scala could not run on the JVM"
+        - "Scala compiled too slowly for a company building a responsive IDE"
+        - "Scala was not open source"
+        - "Scala could not interoperate with Java"
+      correctIndex: 1
+      explanation: "JetBrains liked Scala, but its slow compile times were unacceptable for a company whose business is building fast, responsive developer tools. They needed a JVM language that was concise, safe, interoperable with Java, AND fast to compile — so they built their own."
+    - question: "Where does the name 'Kotlin' come from?"
+      options:
+        - "An acronym for the design team's initials"
+        - "A Russian word meaning 'concise'"
+        - "Kotlin Island, near Saint Petersburg where the team was based"
+        - "The lead designer's hometown"
+      correctIndex: 2
+      explanation: "Kotlin is named after Kotlin Island in the Gulf of Finland, near Saint Petersburg. It follows the tradition set by Java, which was named after the Indonesian island famous for its coffee."
+    - question: "What does the Elvis operator (?:) do in Kotlin?"
+      options:
+        - "Asserts that a value is definitely not null, crashing if it is"
+        - "Safely calls a method, returning null if the receiver is null"
+        - "Supplies a default value when the left-hand expression is null"
+        - "Declares an immutable variable"
+      correctIndex: 2
+      explanation: "The Elvis operator ?: returns its left-hand side if it is non-null, otherwise the right-hand side. So `name ?: \"Guest\"` evaluates to name, or \"Guest\" if name is null. It is named because, rotated on its side, ?: resembles Elvis Presley's hair and eyes."
+    - question: "What are 'platform types' in Kotlin?"
+      options:
+        - "Types that only exist on the Android platform"
+        - "Types coming from Java whose nullability Kotlin cannot determine"
+        - "The four compilation targets: JVM, Native, JS, and Wasm"
+        - "Types that change depending on the operating system"
+      correctIndex: 1
+      explanation: "When Kotlin calls Java code, Java's types carry no nullability information, so Kotlin cannot know if a returned value might be null. These are platform types (written internally as String!). They are a deliberate escape hatch — the price of seamless Java interoperability — and you are trusted to handle them safely."
+    - question: "Which is NOT a Kotlin compilation target?"
+      options:
+        - "Kotlin/JVM (Java bytecode)"
+        - "Kotlin/Native (LLVM native binaries)"
+        - "Kotlin/SQL (database stored procedures)"
+        - "Kotlin/Wasm (WebAssembly)"
+      correctIndex: 2
+      explanation: "Kotlin compiles to JVM bytecode (Kotlin/JVM), native binaries via LLVM (Kotlin/Native), JavaScript (Kotlin/JS), and WebAssembly (Kotlin/Wasm). There is no 'Kotlin/SQL' target — that is invented. This multi-target flexibility is what powers Kotlin Multiplatform."
+    - question: "Why can a program run millions of coroutines but only a few thousand threads?"
+      options:
+        - "Coroutines run on a faster CPU core"
+        - "Coroutines are lightweight and managed by Kotlin; they suspend instead of blocking a thread"
+        - "Threads are limited to one thousand by the Kotlin compiler"
+        - "Coroutines do not actually run concurrently"
+      correctIndex: 1
+      explanation: "Each OS thread reserves around a megabyte of memory and is managed by the operating system, so only a few thousand fit. Coroutines are cheap, managed by Kotlin itself, and suspend (freeing their thread) instead of blocking it while they wait — so millions can run on just a handful of threads."
+    - question: "What does it mean that a basic Kotlin Flow is 'cold'?"
+      options:
+        - "It can only emit numeric values"
+        - "It runs on a background thread automatically"
+        - "Its code runs only when something collects it, fresh for each collector"
+        - "It caches its values forever once produced"
+      correctIndex: 2
+      explanation: "A cold Flow does nothing until a collector subscribes. The code inside the flow { } builder runs only on collection, and runs again from scratch for each new collector. This contrasts with hot streams like SharedFlow or Channel, which produce values whether or not anyone is listening."
+---
+
+{/* Flagship episode of the Kotlin: Foundations series. Covers Kotlin's origins
+    (the Java/Scala backstory, Kotlin Island etymology, the 2011→2016→2017→2019
+    timeline), pragmatic design, null safety (?., ?:, !!, smart casts, platform
+    types), the Google/Android 2017 moment, compilation targets, and a featured
+    deep dive on coroutines (suspend, structured concurrency, threads-vs-coroutines)
+    and Flow. 6 inline SVG diagrams. */}

--- a/src/pages/deep-dives/index.astro
+++ b/src/pages/deep-dives/index.astro
@@ -42,6 +42,10 @@ const categoryMeta: Record<string, { color: string; description: string }> = {
     color: '#02569B',
     description: 'Build beautiful, natively compiled applications from a single codebase.'
   },
+  'Kotlin': {
+    color: '#7F52FF',
+    description: 'Master Kotlin — its origins, pragmatic design, null safety, and the coroutines that make concurrency a joy.'
+  },
   'System Design': {
     color: '#dc2626',
     description: 'Architecture patterns for scalable, maintainable applications.'
@@ -64,6 +68,10 @@ const subjectOrder: Record<string, number> = {
   'Flutter: Navigation': 4,
   'Flutter: Performance': 5,
   'Flutter: Platform Integration': 6,
+  // Kotlin learning path
+  'Kotlin: Foundations': 1,
+  'Kotlin: Type System': 2,
+  'Kotlin: Concurrency': 3,
 };
 ---
 
@@ -186,6 +194,7 @@ const subjectOrder: Record<string, number> = {
         'Dart': '#0175C2',
         'Design Patterns': '#9333ea',
         'Flutter': '#02569B',
+        'Kotlin': '#7F52FF',
         'System Design': '#dc2626',
       };
 


### PR DESCRIPTION
Starts a new **Kotlin** deep-dive series in the same style and depth as the existing Dart series, with history, etymology, language-design context, and gotchas woven throughout to keep it engaging.

## What's included

**1. Flagship — `Why Kotlin Exists` (`kotlin.mdx`, subject: Kotlin: Foundations)**
- JetBrains' Java frustration and why they passed on Scala (compile times)
- Etymology: named after Kotlin Island near Saint Petersburg, echoing Java's coffee island
- The 2011 → 2016 → 2017 → 2019 timeline (Breslav; Google I/O 2017; "Kotlin-first" 2019; the Oracle-v-Google backdrop)
- Pragmatic design, `val`/`var`, data classes
- Null safety: `?.`, `?:` (the Elvis-hair origin), `!!`, smart casts, and the Java-interop platform-type gotcha
- Compilation targets (JVM / Native / JS / Wasm) and Multiplatform
- A featured intro to coroutines and Flow

**2. `Coroutines & Flow` (`kotlin-coroutines.mdx`, subject: Kotlin: Concurrency)**
- The callback pyramid of doom
- suspend vs blocking; coroutines as a unit cheaper than threads
- How `suspend` compiles to a continuation-passing state machine
- `launch` / `async` / `runBlocking`, and the sequential-by-default gotcha
- Dispatchers (Default / IO / Main / Unconfined) and `withContext`
- Structured concurrency, parent-child cancellation
- Cooperative cancellation and its traps
- Cold `Flow`, and hot `StateFlow` / `SharedFlow`

Each episode follows the established format: narrative topics with hand-crafted inline SVG diagrams (12 total, themed in Kotlin violet `#7F52FF`), code samples, an AI-prompts section, and a quiz.

## Integration
- Registered a new `Kotlin` category in `src/pages/deep-dives/index.astro` (`categoryMeta`, `subjectOrder`, and the client-side `categoryColors` map) so it themes in violet and sorts correctly alongside Dart and Flutter. No schema change needed.

## Verification
- `astro build` passes; both pages generate, all SVGs and quizzes render, and the new category tab appears on `/deep-dives/`.

https://claude.ai/code/session_01DbvXsWQWCLCa3bdLp25Hfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbvXsWQWCLCa3bdLp25Hfh)_